### PR TITLE
Auto exclude caching plugin folders

### DIFF
--- a/backwpup.php
+++ b/backwpup.php
@@ -165,6 +165,9 @@ if (!class_exists(\BackWPup::class, false)) {
             if (defined(\WP_CLI::class) && WP_CLI && method_exists(\WP_CLI::class, 'add_command')) {
                 WP_CLI::add_command('backwpup', \BackWPup_WP_CLI::class);
             }
+            // Register the third parties
+	        require_once(__DIR__.DIRECTORY_SEPARATOR.'inc'.DIRECTORY_SEPARATOR.'class-thirdparties.php');
+            BackWPup_ThirdParties::register();
         }
 
         /**

--- a/inc/class-directory.php
+++ b/inc/class-directory.php
@@ -7,6 +7,21 @@
  */
 class BackWPup_Directory extends DirectoryIterator
 {
+
+    /**
+     * The folders list of the plugins to auto exclude
+     *
+     * @var array
+     */
+    static protected $_auto_exclusion_plugins_folders = [];
+
+    /**
+     * The cache folder list of the plugins to auto exclude
+     *
+     * @var array
+     */
+    static protected $_auto_exclusion_plugin_cache_folders = [];
+
     /**
      * Creates the iterator.
      *
@@ -17,5 +32,68 @@ class BackWPup_Directory extends DirectoryIterator
     public function __construct($path)
     {
         parent::__construct(BackWPup_Path_Fixer::fix_path($path));
+    }
+
+    /**
+     * Override the current function to avoid the backup of auto exclude plugins listed in self::$_auto_exclusion_plugins
+     *
+     * @return mixed
+     */
+    public function current():mixed {
+        $item = parent::current();
+        if ($item->isDir() && in_array(trailingslashit($item->getPathname()), self::get_auto_exclusion_plugin_cache_folders())) {
+            $this->next();
+            return $this->current();
+        }
+        return $item;
+    }
+
+    /**
+     * Get the folders of the excluded plugins
+     *
+     * @return array
+     */
+    public static function get_auto_exclusion_plugins_folders():array {
+        if (count(self::$_auto_exclusion_plugins_folders) === 0) {
+            self::_init_auto_exclusion_folders();
+        }
+        return self::$_auto_exclusion_plugins_folders;
+    }
+
+    /**
+     * Get the cache folders of the excluded plugins
+     *
+     * @return array
+     */
+    public static function get_auto_exclusion_plugin_cache_folders():array {
+        if (count(self::$_auto_exclusion_plugin_cache_folders) === 0) {
+            self::_init_auto_exclusion_folders();
+        }
+        return self::$_auto_exclusion_plugin_cache_folders;
+    }
+
+    /**
+     * Init the excluded folders
+     *
+     * @return void
+     */
+    protected static function _init_auto_exclusion_folders() {
+        /**
+         * Filter whether BackWPup will list the plugins in the excluded plugins list.
+         *
+         * @param array $excluded_folders List of excluded paths.
+         */
+        $auto_exclusion_plugins_folders = apply_filters("backwpup_exclusion_plugins_folders",[]);
+        /**
+         * Filter whether BackWPup will list the cache folders to include in the backup.
+         *
+         * @param array $excluded_folders List of excluded paths.
+         */
+        $auto_exclusion_plugins_cache_folders = apply_filters("backwpup_exclusion_plugins_cache_folders",[]);
+        $auto_exclusion_plugins_folders = (!is_array($auto_exclusion_plugins_folders)? [] : $auto_exclusion_plugins_folders);
+        $auto_exclusion_plugins_cache_folders = (!is_array($auto_exclusion_plugins_cache_folders)? [] : $auto_exclusion_plugins_cache_folders);
+
+        self::$_auto_exclusion_plugins_folders = array_unique(array_map('trailingslashit', $auto_exclusion_plugins_folders));
+        self::$_auto_exclusion_plugin_cache_folders = array_unique(array_map('trailingslashit', $auto_exclusion_plugins_cache_folders));
     }
 }

--- a/inc/class-jobtype-file.php
+++ b/inc/class-jobtype-file.php
@@ -527,9 +527,9 @@ class BackWPup_JobType_File extends BackWPup_JobTypes
             try {
                 $dir = new BackWPup_Directory($folder);
                 $excludes = BackWPup_Option::get($jobid, 'backup' . $id . 'excludedirs');
-
                 foreach ($dir as $file) {
-                    if (!$file->isDot() && $file->isDir() && !in_array(trailingslashit($file->getPathname()), $this->get_exclude_dirs($folder), true)) {
+                    // List only the folders without thoses listed by auto exclude
+                    if (!$file->isDot() && $file->isDir() && !in_array(trailingslashit($file->getPathname()), $this->get_exclude_dirs($folder, $dir::get_auto_exclusion_plugins_folders()), true)) {
                         $donotbackup = file_exists($file->getPathname() . '/.donotbackup');
                         $folder_size = (get_site_option('backwpup_cfg_showfoldersize')) ? ' (' . size_format(BackWPup_File::get_folder_size($file->getPathname()), 2) . ')' : '';
                         $title = '';

--- a/inc/class-thirdparties.php
+++ b/inc/class-thirdparties.php
@@ -1,0 +1,407 @@
+<?php
+class BackWPup_ThirdParties {
+
+	/**
+	 * Register all the third parties depending on what plugin is active
+	 * @return void
+	 */
+    public static function register() {
+        if (self::is_wp_rocket_active()) {
+            add_filter("backwpup_exclusion_plugins_folders", [self::class, "exclude_wp_rocket_plugins_folders"]);
+            add_filter("backwpup_exclusion_plugins_cache_folders", [self::class, "exclude_wp_rocket_plugins_cache_folders"]);
+        }
+		if (self::is_hummingbird_performance_active()) {
+			add_filter("backwpup_exclusion_plugins_folders", [self::class, "exclude_hummingbird_performance_plugins_folders"]);
+			add_filter("backwpup_exclusion_plugins_cache_folders", [self::class, "exclude_hummingbird_performance_plugins_cache_folders"]);
+		}
+		if (self::is_w3_total_cache_active()) {
+			add_filter("backwpup_exclusion_plugins_folders", [self::class, "exclude_w3_total_cache_plugins_folders"]);
+			add_filter("backwpup_exclusion_plugins_cache_folders", [self::class, "exclude_w3_total_cache_plugins_cache_folders"]);
+		}
+		if (self::is_wp_super_cache_active()) {
+			add_filter("backwpup_exclusion_plugins_folders", [self::class, "exclude_wp_super_cache_plugins_folders"]);
+			add_filter("backwpup_exclusion_plugins_cache_folders", [self::class, "exclude_wp_super_cache_plugins_cache_folders"]);
+		}
+		if (self::is_breeze_active()) {
+			add_filter("backwpup_exclusion_plugins_folders", [self::class, "exclude_breeze_plugins_folders"]);
+			add_filter("backwpup_exclusion_plugins_cache_folders", [self::class, "exclude_breeze_plugins_cache_folders"]);
+		}
+		if (self::is_autoptimize_active()) {
+			add_filter("backwpup_exclusion_plugins_folders", [self::class, "exclude_autoptimize_plugins_folders"]);
+			add_filter("backwpup_exclusion_plugins_cache_folders", [self::class, "exclude_autoptimize_plugins_cache_folders"]);
+		}
+		if (self::is_wp_optimize_active()) {
+			add_filter("backwpup_exclusion_plugins_folders", [self::class, "exclude_wp_optimize_plugins_folders"]);
+			add_filter("backwpup_exclusion_plugins_cache_folders", [self::class, "exclude_wp_optimize_plugins_cache_folders"]);
+		}
+		if (self::is_sg_cachepress_active()) {
+			add_filter("backwpup_exclusion_plugins_folders", [self::class, "exclude_sg_cachepress_plugins_folders"]);
+			add_filter("backwpup_exclusion_plugins_cache_folders", [self::class, "exclude_sg_cachepress_plugins_cache_folders"]);
+		}
+
+    }
+
+    /**
+     * Add the wp-rocket plugin folders to the $excluded_folders if wp-rocket plugin is active
+     * @param array $excluded_folders
+     * @return array
+     */
+    public static function exclude_wp_rocket_plugins_folders($excluded_folders) {
+        if (
+            !is_array($excluded_folders) ||
+            !self::is_wp_rocket_active() ||
+            in_array(WP_ROCKET_PATH, $excluded_folders)
+        ) {
+            return $excluded_folders;
+        }
+        $excluded_folders[] = WP_ROCKET_PATH;
+        return $excluded_folders;
+    }
+
+	/**
+	 * Add the wp-rocket cache folders to the $excluded_folders if wp-rocket plugin is active
+	 * @param array $excluded_folders
+	 *
+	 * @return array
+	 */
+	public static function exclude_wp_rocket_plugins_cache_folders($excluded_folders) {
+		if (
+			!is_array($excluded_folders) ||
+			!self::is_wp_rocket_active() ||
+			in_array(WP_ROCKET_CACHE_ROOT_PATH, $excluded_folders)
+		) {
+			return $excluded_folders;
+		}
+		$excluded_folders[] = WP_ROCKET_CACHE_ROOT_PATH;
+		return $excluded_folders;
+	}
+
+	/**
+     * Add the hummingbird-performance plugin folders to the $excluded_folders if hummingbird-performance plugin is active
+     * @param array $excluded_folders
+     * @return array
+     */
+    public static function exclude_hummingbird_performance_plugins_folders($excluded_folders) {
+        if (
+            !is_array($excluded_folders) ||
+            !self::is_hummingbird_performance_active() ||
+            in_array(WPHB_DIR_PATH, $excluded_folders)
+        ) {
+            return $excluded_folders;
+        }
+        $excluded_folders[] = WPHB_DIR_PATH;
+        return $excluded_folders;
+    }
+
+	/**
+	 * Add the hummingbird-performance cache folders to the $excluded_folders if hummingbird-performance plugin is active
+	 * @param array $excluded_folders
+	 *
+	 * @return array
+	 */
+	public static function exclude_hummingbird_performance_plugins_cache_folders($excluded_folders) {
+		if (
+			!is_array($excluded_folders) ||
+			!self::is_hummingbird_performance_active()
+		) {
+			return $excluded_folders;
+		}
+		$HummingBirdFilesystem = \Hummingbird\Core\Filesystem::instance();
+		if (!in_array($HummingBirdFilesystem->cache_dir, $excluded_folders)) {
+			$excluded_folders[] = $HummingBirdFilesystem->cache_dir;
+		}
+		if (!in_array($HummingBirdFilesystem->gravatar_dir, $excluded_folders)) {
+			$excluded_folders[] = $HummingBirdFilesystem->gravatar_dir;
+		}
+
+		return $excluded_folders;
+	}
+
+	/**
+     * Add the w3-total-cache plugin folders to the $excluded_folders if w3-total-cache plugin is active
+     * @param array $excluded_folders
+     * @return array
+     */
+    public static function exclude_w3_total_cache_plugins_folders($excluded_folders) {
+        if (
+            !is_array($excluded_folders) ||
+            !self::is_w3_total_cache_active() ||
+            in_array(W3TC_DIR, $excluded_folders)
+        ) {
+            return $excluded_folders;
+        }
+        $excluded_folders[] = W3TC_DIR;
+        return $excluded_folders;
+    }
+
+	/**
+	 * Add the w3-total-cache cache folders to the $excluded_folders if w3-total-cache plugin is active
+	 * @param array $excluded_folders
+	 *
+	 * @return array
+	 */
+	public static function exclude_w3_total_cache_plugins_cache_folders($excluded_folders) {
+		if (
+			!is_array($excluded_folders) ||
+			!self::is_w3_total_cache_active() ||
+			in_array(W3TC_CACHE_DIR, $excluded_folders)
+		) {
+			return $excluded_folders;
+		}
+		$excluded_folders[] = W3TC_CACHE_DIR;
+		return $excluded_folders;
+	}
+
+	/**
+     * Add the wp-super-cache plugin folders to the $excluded_folders if wp-super-cache plugin is active
+     * @param array $excluded_folders
+     * @return array
+     */
+    public static function exclude_wp_super_cache_plugins_folders($excluded_folders) {
+        if (
+            !is_array($excluded_folders) ||
+            !self::is_wp_super_cache_active() ||
+            in_array(WPCACHEHOME, $excluded_folders)
+        ) {
+            return $excluded_folders;
+        }
+        $excluded_folders[] = WPCACHEHOME;
+        return $excluded_folders;
+    }
+
+	/**
+	 * Add the wp-super-cache cache folders to the $excluded_folders if wp-super-cache plugin is active
+	 * @param array $excluded_folders
+	 *
+	 * @return array
+	 */
+	public static function exclude_wp_super_cache_plugins_cache_folders($excluded_folders) {
+		if (
+			!is_array($excluded_folders) ||
+			!self::is_wp_super_cache_active()
+		) {
+			return $excluded_folders;
+		}
+		global $cache_path;
+		if (!in_array($cache_path, $excluded_folders)) {
+			$excluded_folders[] = $cache_path;
+		}
+		return $excluded_folders;
+	}
+
+	/**
+     * Add the breeze plugin folders to the $excluded_folders if breeze plugin is active
+     * @param array $excluded_folders
+     * @return array
+     */
+    public static function exclude_breeze_plugins_folders($excluded_folders) {
+        if (
+            !is_array($excluded_folders) ||
+            !self::is_breeze_active() ||
+            in_array(BREEZE_PLUGIN_DIR, $excluded_folders)
+        ) {
+            return $excluded_folders;
+        }
+        $excluded_folders[] = BREEZE_PLUGIN_DIR;
+        return $excluded_folders;
+    }
+
+	/**
+	 * Add the breeze cache folders to the $excluded_folders if breeze plugin is active
+	 * @param array $excluded_folders
+	 *
+	 * @return array
+	 */
+	public static function exclude_breeze_plugins_cache_folders($excluded_folders) {
+		if (
+			!is_array($excluded_folders) ||
+			!self::is_breeze_active()
+		) {
+			return $excluded_folders;
+		}
+		if (!in_array(BREEZE_MINIFICATION_CACHE, $excluded_folders)) {
+			$excluded_folders[] = BREEZE_MINIFICATION_CACHE;
+		}
+		if (!in_array(BREEZE_MINIFICATION_EXTRA, $excluded_folders)) {
+			$excluded_folders[] = BREEZE_MINIFICATION_EXTRA;
+		}
+		return $excluded_folders;
+	}
+
+	/**
+     * Add the autoptimize plugin folders to the $excluded_folders if autoptimize plugin is active
+     * @param array $excluded_folders
+     * @return array
+     */
+    public static function exclude_autoptimize_plugins_folders($excluded_folders) {
+        if (
+            !is_array($excluded_folders) ||
+            !self::is_autoptimize_active() ||
+            in_array(AUTOPTIMIZE_PLUGIN_DIR, $excluded_folders)
+        ) {
+            return $excluded_folders;
+        }
+        $excluded_folders[] = AUTOPTIMIZE_PLUGIN_DIR;
+        return $excluded_folders;
+    }
+
+	/**
+	 * Add the autoptimize cache folders to the $excluded_folders if autoptimize plugin is active
+	 * @param array $excluded_folders
+	 *
+	 * @return array
+	 */
+	public static function exclude_autoptimize_plugins_cache_folders($excluded_folders) {
+		if (
+			!is_array($excluded_folders) ||
+			!self::is_autoptimize_active() ||
+			in_array(AUTOPTIMIZE_CACHE_DIR, $excluded_folders)
+		) {
+			return $excluded_folders;
+		}
+		$excluded_folders[] = AUTOPTIMIZE_CACHE_DIR;
+		return $excluded_folders;
+	}
+
+	/**
+     * Add the wp-optimize plugin folders to the $excluded_folders if wp-optimize plugin is active
+     * @param array $excluded_folders
+     * @return array
+     */
+    public static function exclude_wp_optimize_plugins_folders($excluded_folders) {
+        if (
+            !is_array($excluded_folders) ||
+            !self::is_wp_optimize_active() ||
+            in_array(WPO_PLUGIN_MAIN_PATH, $excluded_folders)
+        ) {
+            return $excluded_folders;
+        }
+        $excluded_folders[] = WPO_PLUGIN_MAIN_PATH;
+        return $excluded_folders;
+    }
+
+	/**
+	 * Add the wp-optimize cache folders to the $excluded_folders if wp-optimize plugin is active
+	 * @param array $excluded_folders
+	 *
+	 * @return array
+	 */
+	public static function exclude_wp_optimize_plugins_cache_folders($excluded_folders) {
+		if (
+			!is_array($excluded_folders) ||
+			!self::is_wp_optimize_active()
+		) {
+			return $excluded_folders;
+		}
+		if (!in_array(WPO_CACHE_FILES_DIR, $excluded_folders)) {
+			$excluded_folders[] = WPO_CACHE_FILES_DIR;
+		}
+		if (!in_array(WPO_CACHE_MIN_FILES_DIR, $excluded_folders)) {
+			$excluded_folders[] = WPO_CACHE_MIN_FILES_DIR;
+		}
+		return $excluded_folders;
+	}
+
+	/**
+     * Add the sg-cachepress plugin folders to the $excluded_folders if sg-cachepress plugin is active
+     * @param array $excluded_folders
+     * @return array
+     */
+    public static function exclude_sg_cachepress_plugins_folders($excluded_folders) {
+        if (
+            !is_array($excluded_folders) ||
+            !self::is_sg_cachepress_active() ||
+            in_array(SiteGround_Optimizer\DIR, $excluded_folders)
+        ) {
+            return $excluded_folders;
+        }
+        $excluded_folders[] = SiteGround_Optimizer\DIR;
+        return $excluded_folders;
+    }
+
+	/**
+	 * Add the sg-cachepress cache folders to the $excluded_folders if sg-cachepress plugin is active
+	 * @param array $excluded_folders
+	 *
+	 * @return array
+	 */
+	public static function exclude_sg_cachepress_plugins_cache_folders($excluded_folders) {
+		if (
+			!is_array($excluded_folders) ||
+			!self::is_sg_cachepress_active()
+		) {
+			return $excluded_folders;
+		}
+		$file_cacher = new \SiteGround_Optimizer\File_Cacher\File_Cacher();
+		if (!in_array($file_cacher->get_cache_dir(), $excluded_folders)) {
+			$excluded_folders[] = $file_cacher->get_cache_dir();
+		}
+		return $excluded_folders;
+	}
+
+
+
+	/**
+	 * Tells if wp-rocket plugin is active
+	 * @return bool
+	 */
+    protected static function is_wp_rocket_active():bool {
+        return defined( 'WP_ROCKET_VERSION' );
+    }
+
+	/**
+	 * Tells if hummingbird-performance plugin is active
+	 * @return bool
+	 */
+	protected static function is_hummingbird_performance_active():bool {
+		return defined( 'WPHB_VERSION' );
+	}
+
+	/**
+	 * Tells if w3-total-cache plugin is active
+	 * @return bool
+	 */
+	protected static function is_w3_total_cache_active():bool {
+		return defined( 'W3TC' );
+	}
+
+	/**
+	 * Tells if wp-super-cache plugin is active
+	 * @return bool
+	 */
+	protected static function is_wp_super_cache_active():bool {
+		return defined( 'WPSC_VERSION' );
+	}
+
+	/**
+	 * Tells if breeze plugin is active
+	 * @return bool
+	 */
+	protected static function is_breeze_active():bool {
+		return defined( 'BREEZE_VERSION' );
+	}
+
+	/**
+	 * Tells if autoptimize plugin is active
+	 * @return bool
+	 */
+	protected static function is_autoptimize_active():bool {
+		return defined( 'AUTOPTIMIZE_PLUGIN_VERSION' );
+	}
+
+	/**
+	 * Tells if wp-optimize plugin is active
+	 * @return bool
+	 */
+	protected static function is_wp_optimize_active():bool {
+		return defined( 'WPO_VERSION' );
+	}
+
+	/**
+	 * Tells if sg-cachepress plugin is active
+	 * @return bool
+	 */
+	protected static function is_sg_cachepress_active():bool {
+		return defined( 'SiteGround_Optimizer\VERSION' );
+	}
+}


### PR DESCRIPTION
# Description
THAT PR WON'T BE USED IN PRODUCTION.

No issue just an[ epic card](https://www.notion.so/wpmedia/Auto-exclude-caching-plugin-folders-1717ac0b77ed4979bb73a4b8df2f9be2?pvs=4) for that special PR.

As the this repository doesn't have a composer.json file i had to use a require_once in `backwpup.php`.
When that code will be used in a real PR we won't have to keep it.

There is no tests here. We will implement tests in the real PR when the feature will be add to the real repository.

## Documentation

### User documentation

Exclude some plugins folders from the list plugins to exclude from the backup.
Exclude some plugins cache folders from the backup.

### Technical documentation

Add a filter to allow plugins to exclude their cache folders from the backup.
Add a filter to allow plugins to exclude their folder from the exclusion list in backwpup admin.

## Type of change

- [ ] Enhancement (non-breaking change which improves an existing functionality).

