### PR TITLE
Add the deploy ci

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -1,0 +1,20 @@
+name: Deploy to WordPress.org
+on:
+  release:
+    types:
+      - published
+jobs:
+  tag:
+    name: New Release
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: WordPress Plugin Deploy
+        uses: 10up/action-wordpress-plugin-deploy@stable
+        env:
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SLUG: backwpup


### PR DESCRIPTION
# Description

Fixes #130 

## Documentation

### User documentation

To help maintain continuous deployment we add an automatic deployment ci on WP

## Type of change
*Delete options that are not relevant.*

- [x] New feature (non-breaking change which adds functionality).

