### PR TITLE
Rename Database Backup to make type names consistent

### DIFF
--- a/inc/class-jobtype-dbdump.php
+++ b/inc/class-jobtype-dbdump.php
@@ -4,7 +4,7 @@ class BackWPup_JobType_DBDump extends BackWPup_JobTypes
     public function __construct()
     {
         $this->info['ID'] = 'DBDUMP';
-        $this->info['name'] = __('DB Backup', 'backwpup');
+        $this->info['name'] = __('Database', 'backwpup');
         $this->info['description'] = __('Database backup', 'backwpup');
         $this->info['URI'] = __('http://backwpup.com', 'backwpup');
         $this->info['author'] = 'WP Media';


### PR DESCRIPTION
# Description

This change is to make the names consistent, so 'DB Backup' got changed to 'Database' to match 'Files' and 'Plugins' in the Type column.

## Type of change

- [X ] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

see `/wp-admin/admin.php?page=backwpuplogs`

before_
![image](https://github.com/user-attachments/assets/be1339da-ade7-4546-bffc-eb8f732d5078)

after:
![image](https://github.com/user-attachments/assets/4e421f1d-c6e2-4e5a-8c04-514c54ef78a7)

