### PR TITLE
Fix "Next Run" showing 1970 for unscheduled jobs on non-UTC sites

### DIFF
--- a/inc/class-page-jobs.php
+++ b/inc/class-page-jobs.php
@@ -404,8 +404,9 @@ class BackWPup_Page_Jobs extends WP_List_Table {
 			$r .= '<div class="job-normal"' . $job_normal_hide . '>';
 		}
 		if ( 'wpcron' === BackWPup_Option::get( $item, 'activetype' ) ) {
-			$nextrun = wp_next_scheduled( 'backwpup_cron', [ 'arg' => $item ] ) + ( get_option( 'gmt_offset' ) * 3600 );
-			if ( $nextrun ) {
+			$nextrun = wp_next_scheduled( 'backwpup_cron', [ 'arg' => $item ] );
+			if ( false !== $nextrun ) {
+				$nextrun += get_option( 'gmt_offset' ) * 3600;
 				// translators: %s: cron expression.
 				$title = sprintf( esc_html__( 'Cron: %s', 'backwpup' ), BackWPup_Option::get( $item, 'cron' ) );
 				// translators: %1$s: date, %2$s: time.


### PR DESCRIPTION
Fixes #144 (the "next backup scheduled for year 1970" part).

## The bug

On the Jobs list, the WP-Cron "Next Run" cell adds the site's `gmt_offset` to `wp_next_scheduled()` *before* checking whether anything is actually scheduled:

```php
$nextrun = wp_next_scheduled( 'backwpup_cron', [ 'arg' => $item ] ) + ( get_option( 'gmt_offset' ) * 3600 );
if ( $nextrun ) {
    // ...show the date...
} else {
    $r .= __( 'Not scheduled!', 'backwpup' );
}
```

When a job has no scheduled event, `wp_next_scheduled()` returns `false`. In the arithmetic PHP coerces `false` to `0`, so the value becomes `offset * 3600`. On any site whose timezone offset isn't zero that's a small non-zero number, so the `if ( $nextrun )` passes and the cell renders **1970-01-01** (or 1969-12-31 for negative offsets) instead of "Not scheduled!". It only looks right in the UTC (offset 0) case, which is why it slips through.

That's the "next backup gets scheduled for year 1970" the report describes — it's the display, not the schedule itself.

## The fix

Check `wp_next_scheduled()` for `false` first, and only add the offset once there's a real timestamp:

```php
$nextrun = wp_next_scheduled( 'backwpup_cron', [ 'arg' => $item ] );
if ( false !== $nextrun ) {
    $nextrun += get_option( 'gmt_offset' ) * 3600;
    // ...show the date...
} else {
    $r .= __( 'Not scheduled!', 'backwpup' );
}
```

Scheduled jobs render exactly as before; unscheduled ones now correctly say "Not scheduled!" on every timezone.

## Verification

Reproducing the exact expression against a `false` return across a range of offsets:

```
== No event scheduled (wp_next_scheduled === false) ==
offset     0 | before: Not scheduled!                     | after: Not scheduled!
offset   5.5 | before: shows 1970-01-01 05:30 by WP-Cron  | after: Not scheduled!
offset    -6 | before: shows 1969-12-31 18:00 by WP-Cron  | after: Not scheduled!
offset     1 | before: shows 1970-01-01 01:00 by WP-Cron  | after: Not scheduled!
offset  5.75 | before: shows 1970-01-01 05:45 by WP-Cron  | after: Not scheduled!

== A real future event (must be unchanged) ==
offset   5.5 | before: 2026-06-01 14:30 by WP-Cron        | after: 2026-06-01 14:30 by WP-Cron
offset    -6 | before: 2026-06-01 03:00 by WP-Cron        | after: 2026-06-01 03:00 by WP-Cron
```

## Note on the other half of the report

The issue also mentions scheduled jobs only running while an admin is logged in. That part is standard WP-Cron behavior — WP-Cron fires on site traffic, so a low-traffic site can miss runs until the next visit. The usual remedy is a real server cron hitting `wp-cron.php` (or `ALTERNATE_WP_CRON`), and it's separate from this display fix, so I've left it out of scope here. Happy to look at it separately if you'd like.
